### PR TITLE
Add standalone Cytoscape DAG HTML example

### DIFF
--- a/graph_example.html
+++ b/graph_example.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Grafo SQL - Cytoscape DAG</title>
+  <script src="https://unpkg.com/cytoscape@3.28.1/dist/cytoscape.min.js"></script>
+  <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
+  <script src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
+  <style>
+    body {
+      margin: 0;
+      font-family: "Inter", "Segoe UI", sans-serif;
+      background-color: #111827;
+      color: #f9fafb;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+
+    header {
+      padding: 0.75rem 1rem;
+      background-color: #1f2937;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+      z-index: 2;
+    }
+
+    header button {
+      background-color: #2563eb;
+      border: none;
+      color: #f9fafb;
+      padding: 0.4rem 0.9rem;
+      border-radius: 0.375rem;
+      cursor: pointer;
+      font-weight: 600;
+      transition: background-color 0.2s ease;
+    }
+
+    header button:hover {
+      background-color: #1d4ed8;
+    }
+
+    main {
+      flex: 1;
+      display: flex;
+      min-height: 0;
+    }
+
+    #cy {
+      flex: 1;
+      min-height: 0;
+    }
+
+    aside {
+      width: 320px;
+      background-color: #0f172a;
+      border-left: 1px solid #1f2937;
+      padding: 1rem;
+      overflow-y: auto;
+    }
+
+    aside h2 {
+      font-size: 1.05rem;
+      margin-top: 0;
+    }
+
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+
+    .chip {
+      background-color: #1f2937;
+      border-radius: 999px;
+      padding: 0.2rem 0.75rem;
+      font-size: 0.8rem;
+      border: 1px solid #374151;
+    }
+
+    .section-title {
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      color: #9ca3af;
+      letter-spacing: 0.05em;
+      margin-bottom: 0.3rem;
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 1rem 0;
+    }
+
+    li {
+      margin-bottom: 0.4rem;
+      font-size: 0.9rem;
+    }
+
+    .placeholder {
+      color: #6b7280;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <button id="fitBtn">Fit</button>
+    <button id="layoutBtn">Reaplicar layout</button>
+    <button id="toggleLabelsBtn">Ocultar etiquetas de aristas</button>
+  </header>
+  <main>
+    <div id="cy"></div>
+    <aside id="infoPanel">
+      <h2>Selecciona un nodo</h2>
+      <div class="chips">
+        <span class="chip">Catálogo: —</span>
+        <span class="chip">TMP: —</span>
+      </div>
+      <div>
+        <div class="section-title">Fuentes</div>
+        <p class="placeholder">Sin datos</p>
+      </div>
+      <div>
+        <div class="section-title">Destinos</div>
+        <p class="placeholder">Sin datos</p>
+      </div>
+    </aside>
+  </main>
+
+  <script>
+    // =========================
+    // Datos de nodos y aristas
+    // =========================
+    const rawNodes = [
+      "PROD_MODELOS.DBO.UMD_FED_DETALLEBASEMASIVAS",
+      "PROD_MODELOS.DBO.TMPPERFILMOTOSRECURRENTE",
+      "DBO.Reperfilado",
+    ];
+
+    const rawEdges = [
+      {
+        source: "PROD_MODELOS.DBO.UMD_FED_DETALLEBASEMASIVAS",
+        target: "PROD_MODELOS.DBO.TMPPERFILMOTOSRECURRENTE",
+        joinType: "FROM",
+        label: "FROM",
+      },
+      {
+        source: "PROD_MODELOS.DBO.TMPPERFILMOTOSRECURRENTE",
+        target: "DBO.Reperfilado",
+        joinType: "LEFT JOIN",
+        label: "LEFT JOIN por NROORDEN",
+      },
+    ];
+
+    // =========================
+    // Utilidades de metadatos
+    // =========================
+    function parseMetadata(name) {
+      const parts = name.split(".");
+      const hasCatalog = parts.length >= 3;
+      const catalog = hasCatalog ? parts[0] : null;
+      const isTemporary = /TMP|TEMP/i.test(name) || !hasCatalog;
+      return { catalog, isTemporary };
+    }
+
+    const nodes = rawNodes.map((name) => {
+      const { catalog, isTemporary } = parseMetadata(name);
+      return {
+        data: {
+          id: name,
+          label: name,
+          catalog: catalog || "N/A",
+          isTemporary: isTemporary ? 1 : 0,
+        },
+      };
+    });
+
+    const edges = rawEdges.map((edge) => ({
+      data: {
+        id: `${edge.source}__${edge.target}`,
+        source: edge.source,
+        target: edge.target,
+        joinType: edge.joinType,
+        label: edge.label,
+      },
+    }));
+
+    // =========================
+    // Configuración de Cytoscape
+    // =========================
+    cytoscape.use(cytoscapeDagre);
+
+    const cy = cytoscape({
+      container: document.getElementById("cy"),
+      elements: {
+        nodes,
+        edges,
+      },
+      style: [
+        {
+          selector: "node",
+          style: {
+            "shape": "round-rectangle",
+            "background-color": "#1f2937",
+            "border-color": "#374151",
+            "border-width": 1.5,
+            "width": "label",
+            "height": "label",
+            "padding": "12px",
+            "label": "data(label)",
+            "text-wrap": "wrap",
+            "text-max-width": "140px",
+            "color": "#f9fafb",
+            "text-outline-color": "rgba(15,23,42,0.9)",
+            "text-outline-width": 3,
+            "font-size": 12,
+            "text-valign": "center",
+            "text-halign": "center",
+          },
+        },
+        {
+          selector: "node[isTemporary = 1]",
+          style: {
+            "border-color": "#10b981",
+            "border-width": 3,
+          },
+        },
+        {
+          selector: "edge",
+          style: {
+            "curve-style": "bezier",
+            "target-arrow-shape": "triangle",
+            "width": 2,
+            "line-color": "#6b7280",
+            "target-arrow-color": "#6b7280",
+            "label": "data(label)",
+            "color": "#ffffff",
+            "text-outline-color": "rgba(17,24,39,0.85)",
+            "text-outline-width": 2,
+            "text-background-color": "rgba(15,23,42,0.65)",
+            "text-background-opacity": 1,
+            "text-background-padding": 2,
+            "font-size": 11,
+            "text-rotation": "autorotate",
+          },
+        },
+        {
+          selector: 'edge[joinType = "FROM"]',
+          style: {
+            "line-color": "#9ca3af",
+            "target-arrow-color": "#9ca3af",
+            "line-style": "solid",
+          },
+        },
+        {
+          selector: 'edge[joinType = "LEFT JOIN"]',
+          style: {
+            "line-color": "#059669",
+            "target-arrow-color": "#059669",
+            "line-style": "dashed",
+          },
+        },
+        {
+          selector: 'edge[joinType = "RIGHT JOIN"]',
+          style: {
+            "line-color": "#d97706",
+            "target-arrow-color": "#d97706",
+            "line-style": "dashed",
+          },
+        },
+        {
+          selector: 'edge[joinType = "INNER JOIN"]',
+          style: {
+            "line-color": "#2563eb",
+            "target-arrow-color": "#2563eb",
+            "line-style": "solid",
+          },
+        },
+        {
+          selector: 'edge[joinType = "FULL"]',
+          style: {
+            "line-color": "#dc2626",
+            "target-arrow-color": "#dc2626",
+            "line-style": "dashed",
+            "width": 3,
+          },
+        },
+        {
+          selector: 'edge[joinType = "CROSS"]',
+          style: {
+            "line-color": "#7c3aed",
+            "target-arrow-color": "#7c3aed",
+            "line-style": "dashed",
+          },
+        },
+        {
+          selector: ".faded",
+          style: {
+            "opacity": 0.1,
+          },
+        },
+        {
+          selector: ".hide-label",
+          style: {
+            "text-opacity": 0,
+          },
+        },
+      ],
+      layout: {
+        name: "dagre",
+        rankDir: "LR",
+        nodeSep: 80,
+        rankSep: 120,
+        edgeSep: 60,
+      },
+      wheelSensitivity: 0.2,
+    });
+
+    let showEdgeLabels = true;
+
+    function applyLayout() {
+      cy.layout({
+        name: "dagre",
+        rankDir: "LR",
+        nodeSep: 80,
+        rankSep: 120,
+        edgeSep: 60,
+        padding: 20,
+      }).run();
+    }
+
+    applyLayout();
+
+    // =========================
+    // Interacción y panel lateral
+    // =========================
+    const infoPanel = document.getElementById("infoPanel");
+
+    function resetHighlight() {
+      cy.elements().removeClass("faded");
+    }
+
+    function fadeAllExcept(collection) {
+      cy.elements().addClass("faded");
+      collection.removeClass("faded");
+    }
+
+    function updatePanel(node) {
+      const titleEl = infoPanel.querySelector("h2");
+      const chipsEl = infoPanel.querySelector(".chips");
+      const sections = infoPanel.querySelectorAll("div > .section-title");
+      const listsPlaceholders = infoPanel.querySelectorAll("div > .placeholder");
+
+      titleEl.textContent = node ? node.data("label") : "Selecciona un nodo";
+
+      const catalogChip = chipsEl.children[0];
+      const tmpChip = chipsEl.children[1];
+
+      if (node) {
+        catalogChip.textContent = `Catálogo: ${node.data("catalog")}`;
+        tmpChip.textContent = `TMP: ${node.data("isTemporary") ? "Sí" : "No"}`;
+      } else {
+        catalogChip.textContent = "Catálogo: —";
+        tmpChip.textContent = "TMP: —";
+      }
+
+      const sourcesContainer = sections[0].parentElement;
+      const targetsContainer = sections[1].parentElement;
+
+      // Limpiar listas previas
+      sourcesContainer.querySelectorAll("ul").forEach((ul) => ul.remove());
+      targetsContainer.querySelectorAll("ul").forEach((ul) => ul.remove());
+
+      listsPlaceholders.forEach((placeholder) => placeholder.remove());
+
+      if (!node) {
+        const empty = document.createElement("p");
+        empty.className = "placeholder";
+        empty.textContent = "Sin datos";
+        sourcesContainer.appendChild(empty.cloneNode(true));
+        targetsContainer.appendChild(empty);
+        return;
+      }
+
+      const incoming = node.incomers("edge");
+      const outgoing = node.outgoers("edge");
+
+      const sourcesList = document.createElement("ul");
+      if (incoming.length) {
+        incoming.forEach((edge) => {
+          const li = document.createElement("li");
+          li.textContent = `${edge.data("label")} ← ${edge.source().data("label")}`;
+          sourcesList.appendChild(li);
+        });
+        sourcesContainer.appendChild(sourcesList);
+      } else {
+        const empty = document.createElement("p");
+        empty.className = "placeholder";
+        empty.textContent = "Sin fuentes";
+        sourcesContainer.appendChild(empty);
+      }
+
+      const targetsList = document.createElement("ul");
+      if (outgoing.length) {
+        outgoing.forEach((edge) => {
+          const li = document.createElement("li");
+          li.textContent = `${edge.data("label")} → ${edge.target().data("label")}`;
+          targetsList.appendChild(li);
+        });
+        targetsContainer.appendChild(targetsList);
+      } else {
+        const empty = document.createElement("p");
+        empty.className = "placeholder";
+        empty.textContent = "Sin destinos";
+        targetsContainer.appendChild(empty);
+      }
+    }
+
+    cy.on("tap", "node", (event) => {
+      const node = event.target;
+      const neighborhood = node.closedNeighborhood();
+      fadeAllExcept(neighborhood);
+      updatePanel(node);
+    });
+
+    cy.on("tap", (event) => {
+      if (event.target === cy) {
+        resetHighlight();
+        updatePanel(null);
+      }
+    });
+
+    // =========================
+    // Toolbar actions
+    // =========================
+    document.getElementById("fitBtn").addEventListener("click", () => {
+      cy.fit(50);
+    });
+
+    document.getElementById("layoutBtn").addEventListener("click", () => {
+      applyLayout();
+    });
+
+    document.getElementById("toggleLabelsBtn").addEventListener("click", (event) => {
+      showEdgeLabels = !showEdgeLabels;
+      cy.edges().toggleClass("hide-label", !showEdgeLabels);
+      event.target.textContent = showEdgeLabels
+        ? "Ocultar etiquetas de aristas"
+        : "Mostrar etiquetas de aristas";
+    });
+
+    // Asegurar labels visibles inicialmente
+    cy.edges().toggleClass("hide-label", !showEdgeLabels);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML page that renders the provided lineage graph using Cytoscape.js and cytoscape-dagre
- implement node highlighting, metadata side panel, and toolbar controls for layout, fit, and edge label toggling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d442d06f1883318611aa4222bb0dfd