### PR TITLE
Resaltar temporales con verde claro

### DIFF
--- a/salida.html
+++ b/salida.html
@@ -16,7 +16,7 @@
   .legend{display:flex;gap:10px;flex-wrap:wrap;margin-top:6px}
   .dot{width:12px;height:12px;border-radius:3px;display:inline-block}
   .pill{display:inline-block;background:#111827;border:1px solid #374151;border-radius:999px;padding:2px 8px;margin:2px 4px 2px 0;font-size:.8rem}
-  .pill-tmp{background:#064e3b;border-color:#10b981;color:#a7f3d0}
+  .pill-tmp{background:#bbf7d0;border-color:#16a34a;color:#065f46}
   .tmpSummary{background:#111827;border:1px solid #1f2937;border-radius:10px;padding:8px 10px;margin:10px 0;font-size:.9rem}
   .muted{color:#9ca3af}
 </style>
@@ -81,7 +81,14 @@ const cy = cytoscape({
         'text-valign':'center','text-halign':'center',
         'min-zoomed-font-size':8
     }},
-    { selector: 'node.tmp',  style: { 'border-color':'#10b981', 'border-width':3 } },
+    { selector: 'node.tmp',  style: {
+        'background-color':'#bbf7d0',
+        'border-color':'#16a34a',
+        'border-width':3,
+        'color':'#065f46',
+        'text-outline-color':'#bbf7d0',
+        'text-outline-width':1
+    } },
     { selector: 'node.base', style: { } },
 
     // aristas (estilo base)


### PR DESCRIPTION
## Summary
- actualizar el estilo de las insignias y nodos temporales para usar un verde claro distintivo
- ajustar el color del texto y el contorno de las temporales para mantener la legibilidad

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d448a304ac83318f6609747a42b048